### PR TITLE
refactored all methods that used the contract.getPastEvents for the divideAndConquer function to be able to retrieve the whole event's stream no matter the block range

### DIFF
--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -37,9 +37,9 @@ class Content extends Component {
     const latestBlock = await web3.eth.getBlockNumber()
 
     //await subscribeToEvents(exchange, dispatch)
-    await loadAllOrder(exchange, dispatch,latestBlock);
+    await loadAllOrder(exchange, dispatch,latestBlock,provider);
     await loadAllWithdraws(exchange, dispatch,latestBlock,provider)
-    await loadAllDeposits(exchange,dispatch,latestBlock)
+    await loadAllDeposits(exchange,dispatch,latestBlock,provider)
   }
 
   render() {

--- a/src/components/PriceChart.js
+++ b/src/components/PriceChart.js
@@ -36,7 +36,7 @@ class PriceChart extends Component {
 
   render() {
     //console.log("priceChartLoaded",this.props.priceChartLoaded)
-    console.log("priceChart: ",this.props.priceChart)
+    //console.log("priceChart: ",this.props.priceChart)
     return (
       <div className="card bg-dark text-white">
         <div className="card-header">


### PR DESCRIPTION
…sing directly the contract.getPastEvents method for the divideAndConquer function which is able to retrieve all the events no matter the block range